### PR TITLE
FEATURE: Allow SENTRY_RELEASE as env variable and add more data

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -3,6 +3,7 @@ PunktDe:
     Flow:
       dsn: '%env:SENTRY_DSN%'
       environment: '%env:SENTRY_ENVIRONMENT%'
+      release: '%env:SENTRY_RELEASE%'
 Neos:
   Flow:
     error:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,28 @@ PunktDe:
       dsn: 'https://public_key@your-sentry-server.com/project-id'
 ```
 
+You can also set the Sentry Environment to filter your exceptions by e.g. dev-/staging-/live-system. 
+Set the env variable `SENTRY_ENVIRONMENT` or add your value to your `Settings.yaml`: 
+
+```yaml
+PunktDe:
+  Sentry:
+    Flow:
+      environment: 'live'
+```
+
+Furthermore you can set the Sentry Release version to help to identifiy with which release an error occurred the first time.
+By default, a file which is starting with the name `RELEASE_` is searched and the values after `RELEASE_` is used for Sentry.
+Alternatively you can override the filebased release number and set an environment variable `SENTRY_RELEASE` or add your value to your `Settings.yaml`: 
+
+```yaml
+PunktDe:
+  Sentry:
+    Flow:
+      release: '5.0.3'
+```     
+
+
 ## Usage
 
 Sentry will log all exceptions that have the rendering option `logException` enabled. This can be enabled or disabled


### PR DESCRIPTION

This will add the possibility to set a release version via environment variable or via Settings.yaml.
If the env variable SENTRY_RELEASE is not set, nor the key PunktDe.Sentry.Flow.release defined with an string, it will look for
a file in the root directory which is starting with RELEASE_ and takes everything after RELEASE_ for as value for the release tag.

This fixes also a bug with Sentry Environments which won't get correctly generated by using the ->setEnvironment() function.

Some code of this is PR is heavily inspired by the flownative/flow-sentry package.