### PR TITLE
BUGFIX: http_proxy setting defaults to the string '%env:http_proxy%'

### DIFF
--- a/Classes/Handler/ErrorHandler.php
+++ b/Classes/Handler/ErrorHandler.php
@@ -82,13 +82,18 @@ class ErrorHandler
             $release = $this->getReleaseFromReleaseFile();
         }
 
+        $http_proxy = $this->settings['http_proxy'] ? $this->settings['http_proxy'] : '';
+        if ($http_proxy === '%env:http_proxy%') {
+            $http_proxy = '';
+        }
+
         $clientBuilder = ClientBuilder::create(
             [
                 'dsn' => $this->dsn,
                 'environment' => $this->settings['environment'] ? $this->settings['environment'] : '',
                 'release' => $release,
                 'project_root' => FLOW_PATH_ROOT,
-                'http_proxy' => $this->settings['http_proxy'] ? $this->settings['http_proxy'] : '',
+                'http_proxy' => $http_proxy,
                 'prefixes' => [FLOW_PATH_ROOT],
                 'sample_rate' => $this->settings['sample_rate'],
                 'in_app_exclude' => [


### PR DESCRIPTION
I really don't like this solution.

![](https://user-images.githubusercontent.com/616991/91326057-2e066a00-e7c4-11ea-9b9e-d15dcae41136.png)
![](https://user-images.githubusercontent.com/616991/91326061-2e9f0080-e7c4-11ea-8f42-9e8fdbf8758b.png)
