### PR TITLE
Increase php-http/guzzle-adapter from 6 to 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "neos/flow": "^5.0 || ^6.0 || ^7.0",
         "sentry/sdk": "^3.0",
-				"php-http/guzzle7-adapter": "^1.0"
+        "php-http/guzzle7-adapter": "^1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "neos/flow": "^5.0 || ^6.0 || ^7.0",
         "sentry/sdk": "^3.0",
-        "php-http/guzzle6-adapter": "^v2.0"
+				"php-http/guzzle7-adapter": "^1.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Based on a compatibility problem with `punktDe/sentry-flow` and `neos/buildessentials v7.1` who need `guzzlehttp/guzzle v7`